### PR TITLE
luci-base: fix button handling for named sections

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/form.js
+++ b/modules/luci-base/htdocs/luci-static/resources/form.js
@@ -2219,7 +2219,7 @@ var CBITypedSection = CBIAbstractSection.extend(/** @lends LuCI.form.TypedSectio
 
 			if (this.map.readonly !== true) {
 				ui.addValidator(nameEl, 'uciname', true, function(v) {
-					var button = document.querySelector('.cbi-section-create > .cbi-button-add');
+					var button = createEl.querySelector('.cbi-section-create > .cbi-button-add');
 					if (v !== '') {
 						button.disabled = null;
 						return true;


### PR DESCRIPTION
If more than one named section is added to the page, it is currently the case, that the first button is always switched on or off during input validation of the uci section name. This is because the usage of the 'document.querySelector' function is to imprecise. Changing the search start to the element to be created, fixes this.

Signed-off-by: Florian Eckert <fe@dev.tdt.de>
(cherry picked from commit 440a2e79a762b4152ccb7e41c90a2826d9fb3538)