### PR TITLE
luci-base: dispatcher.lua: prevent XSS through 404 error template

### DIFF
--- a/modules/luci-base/luasrc/dispatcher.lua
+++ b/modules/luci-base/luasrc/dispatcher.lua
@@ -1033,7 +1033,7 @@ function dispatch(request)
 			         "Install luci-mod-admin-full and retry. " ..
 			         "If the module is already installed, try removing the /tmp/luci-indexcache file.")
 		else
-			error404("No page is registered at '/" .. table.concat(requested_path_full, "/") .. "'.\n" ..
+			error404("No page is registered at '/" .. xml.pcdata(table.concat(requested_path_full, "/")) .. "'.\n" ..
 			         "If this url belongs to an extension, make sure it is properly installed.\n" ..
 			         "If the extension was recently installed, try removing the /tmp/luci-indexcache file.")
 		end


### PR DESCRIPTION
Make sure to escape the user controlled URL passed as part of the error message into the error404 template in order to avoid XSS.

Reported-by: 40826d <40826d@posteo.de>
Signed-off-by: Jo-Philipp Wich <jo@mein.io>
(backported from commit cd8bea94e61fa72a0a2ba7bc54d7b2d7b7572519)