### PR TITLE
luci-app-banip: fix URL regex in custom feed editor

### DIFF
--- a/applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js
+++ b/applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js
@@ -205,7 +205,7 @@ return view.extend({
 				if (!value) {
 					return true;
 				}
-				if (!value.match(/^(http:\/\/|https:\/\/)[A-Za-z0-9\/\.\-_\?\&\+=~#]+$/)) {
+				if (!value.match(/^(http:\/\/|https:\/\/)[A-Za-z0-9\/\.\-\?\&\+_@%=:~#]+$/)) {
 					return _('Protocol/URL format not supported');
 				}
 				return true;
@@ -218,7 +218,7 @@ return view.extend({
 				if (!value) {
 					return true;
 				}
-				if (!value.match(/^(http:\/\/|https:\/\/)[A-Za-z0-9\/\.\-_\?\&\+=:~#]+$/)) {
+				if (!value.match(/^(http:\/\/|https:\/\/)[A-Za-z0-9\/\.\-\?\&\+_@%=:~#]+$/)) {
 					return _('Protocol/URL format not supported');
 				}
 				return true;


### PR DESCRIPTION
- accept special chars for BASIC AUTH in URL

Signed-off-by: Dirk Brenken <dev@brenken.org>
(cherry picked from commit ceb490df59d23664e409af991e578122e259a65d)