### PR TITLE
luci-app-firewall: add reflection_zone field to forwards

### DIFF
--- a/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js
+++ b/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js
@@ -259,6 +259,12 @@ return view.extend({
 			uci.set('firewall', section_id, 'reflection_src', (value != 'internal') ? value : null);
 		};
 
+		o = s.taboption('advanced', widgets.ZoneSelect, 'reflection_zone', _('Reflection zones'), _('Zones from which reflection rules shall be created. If unset, only the destination zone is used.'));
+		o.nocreate = true;
+		o.multiple = true;
+		o.modalonly = true;
+		o.depends('reflection', '1');
+
 		o = s.taboption('advanced', form.Value, 'helper', _('Match helper'), _('Match traffic using the specified connection tracking helper.'));
 		o.modalonly = true;
 		o.placeholder = _('any');


### PR DESCRIPTION
This allows to to define multiple zones for NAT reflection rules.

Fixes: #1560

Signed-off-by: Julien Cassette <julien.cassette@gmail.com>
(cherry picked from commit 3f20598acf57759aeda8ef5448e60f5a70e532f9)