### PR TITLE
ucode-mod-html: fix build with gcc 5

### DIFF
--- a/contrib/package/ucode-mod-html/src/html.c
+++ b/contrib/package/ucode-mod-html/src/html.c
@@ -2599,6 +2599,7 @@ tokenize_html(const char *s, size_t len, html_token_callback_t cb, void *ud)
 
 		case END:
 			/* not reached */
+			break;
 		}
 	}
 


### PR DESCRIPTION
Older gcc versions raise a `label at end of compound statement` error due to the empty default case. Fix the problem by adding an explicit `break` statement.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>
(cherry picked from commit b3d661cd84760a0cdf084a25f21556a07e369d33)