### PR TITLE
firewall: ipsets.js: validate set names

### DIFF
--- a/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/ipsets.js
+++ b/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/ipsets.js
@@ -41,6 +41,12 @@ return view.extend({
 			o = s.option(form.Value, 'name', _('Name'));
 			o.optional = false;
 			o.rmempty = false;
+			o.validate = function (section_id, value) {
+				if (!/^[a-zA-Z_.][a-zA-Z0-9\/_.-]*$/.test(value))
+					return _('Invalid set name');
+
+				return true;
+			};
 		} else {
 			o = s.option(form.Value, 'name', _('Name'));
 			o.depends({ external: '' });


### PR DESCRIPTION
Ensure that user supplied set name values conform to the nftables identifier syntax constraints.

Fixes: #6633
Fixes: 0484343903 ("luci-app-firewall: implement IPsets GUI")
Signed-off-by: Jo-Philipp Wich <jo@mein.io>
(cherry picked from commit 755edf6fbf65fa2f6b778e7edfd8b56fd1742f70)