### PR TITLE
luci-mod-network: add missing `throw` route type

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js
@@ -53,6 +53,7 @@ return view.extend({
 			o.value('prohibit');
 			o.value('blackhole');
 			o.value('anycast');
+			o.value('throw');
 
 			o = s.taboption('general', form.Value, 'target', _('Target'), _('Network address'));
 			o.rmempty = false;


### PR DESCRIPTION
Ref: https://forum.openwrt.org/t/x/177040
Signed-off-by: Jo-Philipp Wich <jo@mein.io>
(cherry picked from commit b423b4bbcf21d60fd32239699941249ed9c8b7aa)