### PR TITLE
luci-mod-status: fix ordering realtime connections by traffic

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js
@@ -135,7 +135,7 @@ return view.extend({
 				c.layer4.toUpperCase(),
 				'%h'.format(c.hasOwnProperty('sport') ? (src + ':' + c.sport) : src),
 				'%h'.format(c.hasOwnProperty('dport') ? (dst + ':' + c.dport) : dst),
-				'%1024.2mB (%d %s)'.format(c.bytes, c.packets, _('Pkts.'))
+				[ c.bytes, '%1024.2mB (%d %s)'.format(c.bytes, c.packets, _('Pkts.')) ]
 			]);
 		}
 


### PR DESCRIPTION
Add raw byte values to properly order rows by transferred bytes, regardless of the dispalyed unit.

Fixes: #7129
Signed-off-by: Jo-Philipp Wich <jo@mein.io>
(cherry picked from commit e7f2e6bc8ee2bbbfd3d1f7caa570a6529cc03eee)