### PR TITLE
luci-app-opkg: populate alternative package size if needed

### DIFF
--- a/applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js
+++ b/applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js
@@ -310,9 +310,9 @@ function display(pattern)
 		currentDisplayRows.push([
 			name,
 			ver,
-			[ pkg.size || 0,
-			   pkg.size ? '%1024mB'.format(pkg.size)
-			         : (altsize ? '~%1024mB'.format(altsize) : '-') ],
+			[ pkg.size || altsize || 0,
+			  pkg.size ? '%1024mB'.format(pkg.size)
+			           : (altsize ? '~%1024mB'.format(altsize) : '-') ],
 			desc,
 			btn
 		]);


### PR DESCRIPTION
Populate the raw size value with the alternative size if the package size is unavailable.

Fixes: #7139
Fixes: 63e5d38db0 ("luci-app-opkg: fix sorting by size column")
Signed-off-by: Jo-Philipp Wich <jo@mein.io>
(cherry picked from commit 2d2e5c0689b3483b22d033af1da9d33afeedf33e)