### PR TITLE
luci-mod-system: Fix cron log level settings in 23.05

### DIFF
--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js
@@ -159,44 +159,44 @@ return view.extend({
 		 * Logging
 		 */
 
-		o = s.taboption('logging', form.Value, 'log_size', _('System log buffer size'), "kiB")
-		o.optional    = true
-		o.placeholder = 16
-		o.datatype    = 'uinteger'
+		o = s.taboption('logging', form.Value, 'log_size', _('System log buffer size'), "kiB");
+		o.optional    = true;
+		o.placeholder = 128;
+		o.datatype    = 'uinteger';
 
-		o = s.taboption('logging', form.Value, 'log_ip', _('External system log server'))
-		o.optional    = true
-		o.placeholder = '0.0.0.0'
-		o.datatype    = 'host'
+		o = s.taboption('logging', form.Value, 'log_ip', _('External system log server'));
+		o.optional    = true;
+		o.placeholder = '0.0.0.0';
+		o.datatype    = 'host';
 
-		o = s.taboption('logging', form.Value, 'log_port', _('External system log server port'))
-		o.optional    = true
-		o.placeholder = 514
-		o.datatype    = 'port'
+		o = s.taboption('logging', form.Value, 'log_port', _('External system log server port'));
+		o.optional    = true;
+		o.placeholder = 514;
+		o.datatype    = 'port';
 
-		o = s.taboption('logging', form.ListValue, 'log_proto', _('External system log server protocol'))
-		o.value('udp', 'UDP')
-		o.value('tcp', 'TCP')
+		o = s.taboption('logging', form.ListValue, 'log_proto', _('External system log server protocol'));
+		o.value('udp', 'UDP');
+		o.value('tcp', 'TCP');
 
-		o = s.taboption('logging', form.Value, 'log_file', _('Write system log to file'))
-		o.optional    = true
-		o.placeholder = '/tmp/system.log'
+		o = s.taboption('logging', form.Value, 'log_file', _('Write system log to file'));
+		o.optional    = true;
+		o.placeholder = '/tmp/system.log';
 
-		o = s.taboption('logging', form.ListValue, 'conloglevel', _('Log output level'))
-		o.value(8, _('Debug'))
-		o.value(7, _('Info'))
-		o.value(6, _('Notice'))
-		o.value(5, _('Warning'))
-		o.value(4, _('Error'))
-		o.value(3, _('Critical'))
-		o.value(2, _('Alert'))
-		o.value(1, _('Emergency'))
+		o = s.taboption('logging', form.ListValue, 'conloglevel', _('Log output level'), _('Only affects dmesg kernel log'));
+		o.value(8, _('Debug'));
+		o.value(7, _('Info'));
+		o.value(6, _('Notice'));
+		o.value(5, _('Warning'));
+		o.value(4, _('Error'));
+		o.value(3, _('Critical'));
+		o.value(2, _('Alert'));
+		o.value(1, _('Emergency'));
 
-		o = s.taboption('logging', form.ListValue, 'cronloglevel', _('Cron Log Level'))
-		o.default = 8
-		o.value(5, _('Debug'))
-		o.value(8, _('Normal'))
-		o.value(9, _('Warning'))
+		o = s.taboption('logging', form.ListValue, 'cronloglevel', _('Cron Log Level'));
+		o.default = 7;
+		o.value(7, _('Normal'));
+		o.value(9, _('Disabled'));
+		o.value(5, _('Debug'));
 
 		/*
 		 * Zram Properties


### PR DESCRIPTION
Busybox crond only uses level 5, 7 and 8. (And 7 and 8 only differ on one error regarding finding a crontab without user.)

For simplicity, just provide 5 and 7 as alternatives in LuCI. Add "Disabled" with value 9 as a choice for cron log level.

9 actually exceeds the highest built-in value 8, but can be used to quieten the logging in cases where there are e.g. cron jobs running each minute, which would create log spam.

Show level 7 as the default and as the first offered choice.

Add missing semicolons to the file.

Signed-off-by: Hannu Nyman <hannu.nyman@iki.fi>
(cherry picked from commit 1e7ce8de990e0bcb36b77bdb846b644aa1724568) (cherry picked from commit ef167782ffc6b700f133557a9196ac846edb3399) [also modernize system log size placeholder value]